### PR TITLE
Make lib importable on typescript projects

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,0 +1,1 @@
+declare module "ethereum-input-data-decoder"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "include": [
+    "dist/*"
+  ],
+  "exclude": [],
+  "compilerOptions": {
+    "lib": [
+      "es2015",
+      "dom",
+      "dom.iterable"
+    ],
+    "target": "ES2018",
+    "declaration": true,
+    "declarationDir": ".",
+    "noEmitOnError": true,
+    "noErrorTruncation": true,
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "baseUrl": ".",
+  }
+}


### PR DESCRIPTION
Fixes the "Module not Found" issue when trying to import this lib from a Typescript project, like so:

`import InputDataDecoder from "ethereum-input-data-decoder`.

Thanks a lot for the lib :seedling: 