### PR TITLE
fix: upgrade meow to fix CVE issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ethereumjs-abi": "^0.6.7",
     "ethers": "^4.0.27",
     "is-buffer": "^2.0.3",
-    "meow": "^5.0.0"
+    "meow": "^10.1.1"
   },
   "keywords": [
     "ethereum",


### PR DESCRIPTION
There are 2 high severity CVE's that are triggered because we use this package and it depends on an old version of meow. 

- trim-newlines
- yargs-parser

This PR upgrades the version of meow.