### PR TITLE
Add real TypeScript definitions

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,4 +1,5 @@
-import { AbiItem } from "web3-utils";
+import Buffer from 'buffer';
+import { Interface } from "ethers/utils";
 
 type NestedArray<T> = T | NestedArray<T>[];
 
@@ -10,7 +11,7 @@ export interface InputData {
 }
 
 export default class InputDataDecoder {
-  constructor(abi: string | AbiItem[]);
+  constructor(abi: string | Interface['abi']);
 
   decodeConstructor(data: Buffer | string): InputData;
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,1 +1,18 @@
-declare module "ethereum-input-data-decoder"
+import { AbiItem } from "web3-utils";
+
+type NestedArray<T> = T | NestedArray<T>[];
+
+export interface InputData {
+  method: string | null;
+  types: string[];
+  inputs: any[];
+  names: NestedArray<string>[];
+}
+
+export default class InputDataDecoder {
+  constructor(abi: string | AbiItem[]);
+
+  decodeConstructor(data: Buffer | string): InputData;
+
+  decodeData(data: Buffer | string): InputData;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
-import { AbiItem } from "web3-utils";
+import Buffer from 'buffer';
+import { Interface } from "ethers/utils";
 
 type NestedArray<T> = T | NestedArray<T>[];
 
@@ -10,7 +11,7 @@ export interface InputData {
 }
 
 export default class InputDataDecoder {
-  constructor(abi: string | AbiItem[]);
+  constructor(abi: string | Interface['abi']);
 
   decodeConstructor(data: Buffer | string): InputData;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,1 +1,18 @@
-declare module "ethereum-input-data-decoder"
+import { AbiItem } from "web3-utils";
+
+type NestedArray<T> = T | NestedArray<T>[];
+
+export interface InputData {
+  method: string | null;
+  types: string[];
+  inputs: any[];
+  names: NestedArray<string>[];
+}
+
+export default class InputDataDecoder {
+  constructor(abi: string | AbiItem[]);
+
+  decodeConstructor(data: Buffer | string): InputData;
+
+  decodeData(data: Buffer | string): InputData;
+}

--- a/package.json
+++ b/package.json
@@ -33,12 +33,14 @@
     "url": "https://github.com/miguelmota/ethereum-input-data-decoder/blob/master/LICENSE"
   },
   "dependencies": {
+    "@types/node": "^16.7.13",
     "bn.js": "^4.11.8",
     "buffer": "^5.2.1",
     "ethereumjs-abi": "^0.6.7",
     "ethers": "^4.0.27",
     "is-buffer": "^2.0.3",
-    "meow": "^10.1.1"
+    "meow": "^10.1.1",
+    "web3-utils": "^1.5.2"
   },
   "keywords": [
     "ethereum",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "ethereumjs-abi": "^0.6.7",
     "ethers": "^4.0.27",
     "is-buffer": "^2.0.3",
-    "meow": "^10.1.1",
-    "web3-utils": "^1.5.2"
+    "meow": "^10.1.1"
   },
   "keywords": [
     "ethereum",


### PR DESCRIPTION
It was impossible to use the exported class as a type with just a stub-like module declaration.

I had to add two additional dependencies: `@types/node` `web3-utils`. I hope you don't mind.
